### PR TITLE
Refactor/item updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
+        "php": ">=7.0",
         "crysalead/kahlan": "^1.2"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -56,6 +56,10 @@
                 "testing",
                 "unit test"
             ],
+            "support": {
+                "issues": "https://github.com/crysalead/kahlan/issues",
+                "source": "https://github.com/crysalead/kahlan/tree/1.3"
+            },
             "abandoned": "kahlan/kahlan",
             "time": "2016-05-01T23:20:41+00:00"
         }
@@ -66,5 +70,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/spec/GildedRoseSpec.php
+++ b/spec/GildedRoseSpec.php
@@ -151,7 +151,6 @@ describe('Gilded Rose', function () {
                 expect($gr->getItem(0)->sellIn)->toBe(-2);
             });
         });
-        /*
         context("Conjured Items", function () {
             it('updates Conjured items before the sell date', function () {
                 $gr = new GildedRose([new Item('Conjured Mana Cake', 10, 10)]);
@@ -190,6 +189,5 @@ describe('Gilded Rose', function () {
                 expect($gr->getItem(0)->sellIn)->toBe(-11);
             });
         });
-        */
     });
 });

--- a/spec/ItemFactorySpec.php
+++ b/spec/ItemFactorySpec.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Items\AgedBrie;
+use App\Items\BackstagePass;
+use App\Items\Conjured;
+use App\Item;
+use App\ItemFactory;
+use App\Items\StandardItem;
+use App\Items\Sulfuras;
+
+describe('Item Factory', function () {
+    describe('Get Item child class from parent', function () {
+        context('Get child Item instance', function () {
+            it('gets a StandardItem item instance', function () {
+                expect(ItemFactory::getInstance(new Item('standarditem', 10, 5)))
+                    ->toBeAnInstanceOf(StandardItem::class);
+            });
+
+            it('gets an AgedBrie item instance', function () {
+                expect(ItemFactory::getInstance(new Item(ItemFactory::ITEM_NAME_AGED_BRIE, 10, 5)))
+                    ->toBeAnInstanceOf(AgedBrie::class);
+            });
+
+            it('gets an BackstagePass item instance', function () {
+                expect(ItemFactory::getInstance(new Item(ItemFactory::ITEM_NAME_BACKSTAGE_PASS, 10, 5)))
+                    ->toBeAnInstanceOf(BackstagePass::class);
+            });
+
+            it('gets an Sulfuras item instance', function () {
+                expect(ItemFactory::getInstance(new Item(ItemFactory::ITEM_NAME_SULFURAS, 10, 5)))
+                    ->toBeAnInstanceOf(Sulfuras::class);
+            });
+
+            it('gets an Conjured item instance', function () {
+                expect(ItemFactory::getInstance(new Item(ItemFactory::ITEM_NAME_CONJURED, 10, 5)))
+                    ->toBeAnInstanceOf(Conjured::class);
+            });
+        });
+    });
+});

--- a/src/GildedRose.php
+++ b/src/GildedRose.php
@@ -4,67 +4,26 @@ namespace App;
 
 class GildedRose
 {
-    private $items;
+    private array $items;
 
     public function __construct(array $items)
     {
         $this->items = $items;
     }
 
+    /**
+     * @param null $which
+     * @return array|mixed
+     */
     public function getItem($which = null)
     {
-        return ($which === null
-            ? $this->items
-            : $this->items[$which]
-        );
+        return $this->items[$which] ?? $this->items;
     }
 
     public function nextDay()
     {
-        foreach ($this->items as $item) {
-            if ($item->name != 'Aged Brie' and $item->name != 'Backstage passes to a TAFKAL80ETC concert') {
-                if ($item->quality > 0) {
-                    if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                        $item->quality = $item->quality - 1;
-                    }
-                }
-            } else {
-                if ($item->quality < 50) {
-                    $item->quality = $item->quality + 1;
-                    if ($item->name == 'Backstage passes to a TAFKAL80ETC concert') {
-                        if ($item->sellIn < 11) {
-                            if ($item->quality < 50) {
-                                $item->quality = $item->quality + 1;
-                            }
-                        }
-                        if ($item->sellIn < 6) {
-                            if ($item->quality < 50) {
-                                $item->quality = $item->quality + 1;
-                            }
-                        }
-                    }
-                }
-            }
-            if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                $item->sellIn = $item->sellIn - 1;
-            }
-            if ($item->sellIn < 0) {
-                if ($item->name != 'Aged Brie') {
-                    if ($item->name != 'Backstage passes to a TAFKAL80ETC concert') {
-                        if ($item->quality > 0) {
-                            if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                                $item->quality = $item->quality - 1;
-                            }
-                        }
-                    } else {
-                        $item->quality = $item->quality - $item->quality;
-                    }
-                } else {
-                    if ($item->quality < 50) {
-                        $item->quality = $item->quality + 1;
-                    }
-                }
-            }
-        }
+        array_walk($this->items, function ($item) {
+            ItemFactory::getInstance($item)->update($item);
+        });
     }
 }

--- a/src/ItemFactory.php
+++ b/src/ItemFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace App;
+
+use App\Items\AgedBrie;
+use App\Items\BackstagePass;
+use App\Items\Conjured;
+use App\Items\ItemInterface;
+use App\Items\StandardItem;
+use App\Items\Sulfuras;
+
+class ItemFactory
+{
+    const ITEM_NAME_AGED_BRIE = 'Aged Brie';
+    const ITEM_NAME_BACKSTAGE_PASS = 'Backstage passes to a TAFKAL80ETC concert';
+    const ITEM_NAME_SULFURAS = 'Sulfuras, Hand of Ragnaros';
+    const ITEM_NAME_CONJURED = 'Conjured Mana Cake';
+    const ITEM_NAME_DEFAULT = 'Default';
+
+    private static $classMap = [
+        self::ITEM_NAME_AGED_BRIE => AgedBrie::class,
+        self::ITEM_NAME_BACKSTAGE_PASS => BackstagePass::class,
+        self::ITEM_NAME_SULFURAS => Sulfuras::class,
+        self::ITEM_NAME_CONJURED => Conjured::class,
+        self::ITEM_NAME_DEFAULT => StandardItem::class,
+    ];
+
+    public static function getInstance(Item $item): ItemInterface
+    {
+        $class = self::$classMap[$item->name] ?? self::$classMap[self::ITEM_NAME_DEFAULT];
+
+        return new $class ($item->name, $item->quality, $item->sellIn);
+    }
+
+}

--- a/src/Items/AgedBrie.php
+++ b/src/Items/AgedBrie.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Items;
+
+use App\Item;
+
+class AgedBrie implements ItemInterface
+{
+
+    /**
+     * @param Item $item
+     */
+    public function update(Item $item)
+    {
+        $item->sellIn -= 1;
+        $item->quality = $item->sellIn < 1 ?
+            min(50, $item->quality + 2) :
+            min(50, $item->quality + 1);
+    }
+}

--- a/src/Items/BackstagePass.php
+++ b/src/Items/BackstagePass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Items;
+
+use App\Item;
+
+class BackstagePass extends Item implements ItemInterface
+{
+
+    public function update(Item $item)
+    {
+        $item->sellIn -= 1;
+        $this->calculateQuality($item);
+    }
+
+    protected function calculateQuality(Item $item)
+    {
+        if ($item->sellIn < 0) {
+            $item->quality = 0;
+        } elseif ($this->sellIn > 10) {
+            $item->quality += 1;
+        } elseif ($this->sellIn > 5) {
+            $item->quality += 2;
+        } else {
+            $item->quality += 3;
+        }
+
+        $item->quality = min(50, $item->quality);
+    }
+}

--- a/src/Items/Conjured.php
+++ b/src/Items/Conjured.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Items;
+
+use App\Item;
+
+class Conjured extends Item implements ItemInterface
+{
+
+    public function update(Item $item)
+    {
+        $item->sellIn -= 1;
+        $item->quality = $item->sellIn < 1 ?
+            max(0, $item->quality - 4) :
+            max(0, $item->quality - 2);
+    }
+}

--- a/src/Items/ItemInterface.php
+++ b/src/Items/ItemInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Items;
+
+use App\Item;
+
+interface ItemInterface
+{
+    public function update(Item $item);
+}

--- a/src/Items/StandardItem.php
+++ b/src/Items/StandardItem.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Items;
+
+use App\Item;
+
+class StandardItem extends Item implements ItemInterface
+{
+    public function update(Item $item)
+    {
+        $item->sellIn -= 1;
+        $item->quality = $item->sellIn < 1 ?
+            max(0, $item->quality - 2) :
+            max(0, $item->quality - 1);
+    }
+}

--- a/src/Items/Sulfuras.php
+++ b/src/Items/Sulfuras.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Items;
+
+use App\Item;
+
+class Sulfuras extends Item implements ItemInterface
+{
+
+    public function update(Item $item)
+    {
+        // do nothing
+    }
+}


### PR DESCRIPTION
- Extracted out item 'types' into child classes of item and implemented their quality and sellIn attribute updates as per the update() method as defined in ItemInterface.php
- To avoid 'insta-rage' I created a StandardItem.php class for the default item behaviours. But I would of preferred to alter Item.php to implement ItemInterface.php and the standard update() functionality.
- Created ItemFactory to generate the correct child instances to perform updates on the Item. Also added test file for this also.
- Updated getItem() to make use of null colleasce functionality.
- Updated nextDay() to use the classes to perform updates
- Been using versions of PHP7 and above for a while now, and noticed I've used some features exclusive to the newer versions automatically. So added min PHP version as composer dependency


![image](https://user-images.githubusercontent.com/20258782/131746369-49d80c96-4fc0-4d89-91bf-f9fc2b9ae750.png)
