### PR TITLE
My solution for the Gilded Rose kata.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -56,6 +56,10 @@
                 "testing",
                 "unit test"
             ],
+            "support": {
+                "issues": "https://github.com/crysalead/kahlan/issues",
+                "source": "https://github.com/crysalead/kahlan/tree/1.3"
+            },
             "abandoned": "kahlan/kahlan",
             "time": "2016-05-01T23:20:41+00:00"
         }
@@ -66,5 +70,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/spec/GildedRoseSpec.php
+++ b/spec/GildedRoseSpec.php
@@ -151,7 +151,7 @@ describe('Gilded Rose', function () {
                 expect($gr->getItem(0)->sellIn)->toBe(-2);
             });
         });
-        /*
+
         context("Conjured Items", function () {
             it('updates Conjured items before the sell date', function () {
                 $gr = new GildedRose([new Item('Conjured Mana Cake', 10, 10)]);
@@ -190,6 +190,5 @@ describe('Gilded Rose', function () {
                 expect($gr->getItem(0)->sellIn)->toBe(-11);
             });
         });
-        */
     });
 });

--- a/src/AgedBrie.php
+++ b/src/AgedBrie.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App;
+
+class AgedBrie implements ItemTypeInterface{
+
+    public $item;
+
+    function __construct($item)
+    {
+        $this->item = $item;
+    }
+
+    function nextDay()
+    {
+        $this->updateSellIn();
+        $this->updateQuality();
+    }
+
+    function updateSellIn()
+    {
+        $this->item->sellIn -= 1;
+    }
+
+    function updateQuality()
+    {
+        // Deduct 1 quality before sellIn date, 2 from then on
+        $this->item->quality += ($this->item->sellIn > 0 ? 1 : 2);
+        
+        // Restrict quality at 50 (top)
+        if($this->item->quality > 50) $this->item->quality = 50;
+    }
+}

--- a/src/BackstagePasses.php
+++ b/src/BackstagePasses.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App;
+
+class BackstagePasses implements ItemTypeInterface{
+
+    public $item;
+
+    function __construct($item)
+    {
+        $this->item = $item;
+    }
+
+    function nextDay()
+    {
+        $this->updateQuality();
+        $this->updateSellIn();
+    }
+
+    function updateSellIn()
+    {
+        $this->item->sellIn -= 1;
+    }
+
+    function updateQuality()
+    {
+        // Restrict quality at 50 (top)
+        if($this->item->quality >= 50) {
+            $this->item->quality = 50;
+            return;
+        }
+
+        // Restrict quality at 0 (bottom)
+        if($this->item->sellIn <= 0) {
+            $this->item->quality = 0;
+            return;
+        }
+
+        if($this->item->sellIn <= 6){
+            $qualityInc = 3;
+        } elseif($this->item->sellIn < 11){
+            $qualityInc = 2;
+        } else {
+            $qualityInc = 1;
+        }
+
+        $this->item->quality += $qualityInc;
+    }
+}

--- a/src/Conjured.php
+++ b/src/Conjured.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App;
+
+class Conjured implements ItemTypeInterface{
+
+    public $item;
+
+    function __construct($item)
+    {
+        $this->item = $item;
+    }
+
+    function nextDay()
+    {
+        $this->updateSellIn();
+        $this->updateQuality();
+    }
+
+    function updateSellIn()
+    {
+        $this->item->sellIn -= 1;
+    }
+
+    function updateQuality()
+    {
+        // Deduct 2 quality before sellIn date, 4 from then on
+        $this->item->quality -= ($this->item->sellIn > 0 ? 2 : 4);
+
+        // Restrict quality at 50 (top)
+        if($this->item->quality > 50) $this->item->quality = 50;
+
+        // Restrict quality at 0 (bottom)
+        if($this->item->quality < 0) $this->item->quality = 0;
+    }
+}

--- a/src/GildedRose.php
+++ b/src/GildedRose.php
@@ -6,6 +6,14 @@ class GildedRose
 {
     private $items;
 
+    // Keeping inline with SOLID priciples, this array can be updated to accept new product types
+    private static $itemTypes = [
+        'Aged Brie' => AgedBrie::class,
+        'Sulfuras, Hand of Ragnaros'  => Sulfuras::class,
+        'Backstage passes to a TAFKAL80ETC concert' => BackstagePasses::class,
+        'Conjured Mana Cake'  => Conjured::class
+    ];
+
     public function __construct(array $items)
     {
         $this->items = $items;
@@ -22,49 +30,13 @@ class GildedRose
     public function nextDay()
     {
         foreach ($this->items as $item) {
-            if ($item->name != 'Aged Brie' and $item->name != 'Backstage passes to a TAFKAL80ETC concert') {
-                if ($item->quality > 0) {
-                    if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                        $item->quality = $item->quality - 1;
-                    }
-                }
+            if(array_key_exists($item->name, self::$itemTypes)){
+                $item = new self::$itemTypes[$item->name]($item);
             } else {
-                if ($item->quality < 50) {
-                    $item->quality = $item->quality + 1;
-                    if ($item->name == 'Backstage passes to a TAFKAL80ETC concert') {
-                        if ($item->sellIn < 11) {
-                            if ($item->quality < 50) {
-                                $item->quality = $item->quality + 1;
-                            }
-                        }
-                        if ($item->sellIn < 6) {
-                            if ($item->quality < 50) {
-                                $item->quality = $item->quality + 1;
-                            }
-                        }
-                    }
-                }
+                $item = new Normal($item);
             }
-            if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                $item->sellIn = $item->sellIn - 1;
-            }
-            if ($item->sellIn < 0) {
-                if ($item->name != 'Aged Brie') {
-                    if ($item->name != 'Backstage passes to a TAFKAL80ETC concert') {
-                        if ($item->quality > 0) {
-                            if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                                $item->quality = $item->quality - 1;
-                            }
-                        }
-                    } else {
-                        $item->quality = $item->quality - $item->quality;
-                    }
-                } else {
-                    if ($item->quality < 50) {
-                        $item->quality = $item->quality + 1;
-                    }
-                }
-            }
+            // Process the "next day" scenario
+            $item->nextDay();
         }
     }
 }

--- a/src/ItemTypeInterface.php
+++ b/src/ItemTypeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+interface ItemTypeInterface 
+{
+    public function nextDay();
+    public function updateQuality();
+    public function updateSellIn();
+}

--- a/src/Normal.php
+++ b/src/Normal.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App;
+
+class Normal implements ItemTypeInterface{
+
+    public $item;
+
+    function __construct($item)
+    {
+        $this->item = $item;
+    }
+
+    public function nextDay()
+    {
+        $this->updateSellIn();
+        $this->updateQuality();
+    }
+
+    function updateSellIn()
+    {
+        $this->item->sellIn -= 1;
+    }
+
+    function updateQuality()
+    {
+        // Deduct 1 quality before sellIn date, 2 from then on
+        $this->item->quality -= ($this->item->sellIn > 0 ? 1 : 2);
+        
+        // Restrict quality at 50 (top)
+        if($this->item->quality > 50) $this->item->quality = 50;
+
+        // Restrict quality at 50 (bottom)
+        if($this->item->quality < 0) $this->item->quality = 0;
+    }
+}

--- a/src/Sulfuras.php
+++ b/src/Sulfuras.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App;
+
+class Sulfuras implements ItemTypeInterface {
+
+    public $item;
+
+    function __construct($item)
+    {
+        $this->item = $item;
+    }
+
+    function nextDay()
+    {
+
+    }
+
+    function updateQuality()
+    {
+        // Item type does not degrade in quality
+    }
+
+    function updateSellIn()
+    {
+        // Item never needs to be sold
+    }
+
+}


### PR DESCRIPTION
- Extracted out item 'item types' into classes and defined nextDay, updateSellIn, and updateQuality methods as specified in ItemTypeInterface.php

- I would have preferred to update Item.php to implement the ItemTypeInterface and have a standardized method-set across each unique item type class but since this wasn't possible I decided against extending the Item class directly.

- I spent just shy of an hour on this, however with more time I'd have put all item type classes into their own directory and perhaps created a routing class to push items to the correct subclass to further refactor out the need for "in_array", inside of GildedRose.php 