### PR TITLE
Completed Kata for Elucidat test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 .phpunit.result.cache
+.idea

--- a/src/GildedRose.php
+++ b/src/GildedRose.php
@@ -21,50 +21,9 @@ class GildedRose
 
     public function nextDay()
     {
-        foreach ($this->items as $item) {
-            if ($item->name != 'Aged Brie' and $item->name != 'Backstage passes to a TAFKAL80ETC concert') {
-                if ($item->quality > 0) {
-                    if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                        $item->quality = $item->quality - 1;
-                    }
-                }
-            } else {
-                if ($item->quality < 50) {
-                    $item->quality = $item->quality + 1;
-                    if ($item->name == 'Backstage passes to a TAFKAL80ETC concert') {
-                        if ($item->sellIn < 11) {
-                            if ($item->quality < 50) {
-                                $item->quality = $item->quality + 1;
-                            }
-                        }
-                        if ($item->sellIn < 6) {
-                            if ($item->quality < 50) {
-                                $item->quality = $item->quality + 1;
-                            }
-                        }
-                    }
-                }
-            }
-            if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                $item->sellIn = $item->sellIn - 1;
-            }
-            if ($item->sellIn < 0) {
-                if ($item->name != 'Aged Brie') {
-                    if ($item->name != 'Backstage passes to a TAFKAL80ETC concert') {
-                        if ($item->quality > 0) {
-                            if ($item->name != 'Sulfuras, Hand of Ragnaros') {
-                                $item->quality = $item->quality - 1;
-                            }
-                        }
-                    } else {
-                        $item->quality = $item->quality - $item->quality;
-                    }
-                } else {
-                    if ($item->quality < 50) {
-                        $item->quality = $item->quality + 1;
-                    }
-                }
-            }
-        }
+        // Alter the state of every item in the array
+        array_walk($this->items, function($item){
+            $item->nextDay();
+        });
     }
 }

--- a/src/ItemTypes/AgedBrie.php
+++ b/src/ItemTypes/AgedBrie.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\ItemTypes;
+
+use App\Item;
+
+final class AgedBrie extends NormalItem
+{
+
+    public function __construct($quality, $sellIn)
+    {
+        parent::__construct($quality, $sellIn, 'Aged Brie');
+    }
+
+    protected function processQuality()
+    {
+        if ($this->sellIn > 0) {
+            $this->quality++;
+        } else {
+            $this->quality = $this->quality + 2;
+        }
+    }
+
+}

--- a/src/ItemTypes/BackstagePass.php
+++ b/src/ItemTypes/BackstagePass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\ItemTypes;
+
+final class BackstagePass extends NormalItem
+{
+
+    protected function processQuality()
+    {
+        if ($this->sellIn <= 0) {
+            // Quality drops to 0 after the concert
+            $this->quality = 0;
+        } elseif ($this->sellIn <= 5 ) {
+            // Quality increases by 3 when there are 5 days or less
+            $this->quality = $this->quality + 3;
+        } elseif ($this->sellIn <= 10) {
+            // Quality increases by 2 when there are 10 days or less
+            $this->quality = $this->quality + 2;
+        } else {
+            // "Backstage passes", like aged brie, increases in Quality as its SellIn value approaches
+            $this->quality++;
+        }
+    }
+
+}

--- a/src/ItemTypes/ConjuredItem.php
+++ b/src/ItemTypes/ConjuredItem.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\ItemTypes;
+
+final class ConjuredItem extends NormalItem
+{
+    // "Conjured" items degrade in Quality twice as fast as normal items
+    protected $degradeAmount = 2;
+}

--- a/src/ItemTypes/LegendaryItem.php
+++ b/src/ItemTypes/LegendaryItem.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\ItemTypes;
+
+final class LegendaryItem extends NormalItem
+{
+    public function __construct($quality, $sellIn, $name)
+    {
+        parent::__construct(80, $sellIn, $name);
+    }
+
+    public function nextDay(){
+        return;
+    }
+}

--- a/src/ItemTypes/NormalItem.php
+++ b/src/ItemTypes/NormalItem.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\ItemTypes;
+
+use App\Item;
+
+class NormalItem extends Item
+{
+
+    protected $degradeAmount = 1;
+
+    public function __construct($quality, $sellIn, $name = 'Normal')
+    {
+        parent::__construct($name, $quality, $sellIn);
+    }
+
+    public function nextDay()
+    {
+        $this->processQuality();
+        $this->processSellin();
+
+        $this->qualityOverrides();
+    }
+
+    protected function processQuality()
+    {
+        // At the end of each day quality is decreased by 1
+        // Once the sell by date has passed, quality degrades twice as fast
+        if ($this->sellIn > 0) {
+            $this->quality = $this->quality - $this->degradeAmount;
+        } else {
+            $this->quality = $this->quality - ($this->degradeAmount * 2);
+        }
+    }
+
+    private function qualityOverrides()
+    {
+        // The Quality of an item is never negative
+        if ($this->quality < 0) {
+            $this->quality = 0;
+        }
+
+        // The Quality of an item is never more than 50
+        if ($this->quality > 50) {
+            $this->quality = 50;
+        }
+    }
+
+    protected function processSellin()
+    {
+        // At the end of each day sellIn is decreased by 1
+        $this->sellIn--;
+    }
+
+}

--- a/tests/Unit/GuildedRoseTest.php
+++ b/tests/Unit/GuildedRoseTest.php
@@ -4,6 +4,11 @@ namespace Tests\Unit;
 
 use App\Item;
 use App\GildedRose;
+use App\ItemTypes\AgedBrie;
+use App\ItemTypes\BackstagePass;
+use App\ItemTypes\ConjuredItem;
+use App\ItemTypes\LegendaryItem;
+use App\ItemTypes\NormalItem;
 use PHPUnit\Framework\TestCase;
 
 class GuildedRoseTest extends TestCase
@@ -21,13 +26,13 @@ class GuildedRoseTest extends TestCase
         int $expectedQuality,
         int $expectedSellIn
     ): void {
-        $gr = new GildedRose([$item]);
+        $gildedRose = new GildedRose([$item]);
 
-        $gr->nextDay();
+        $gildedRose->nextDay();
 
-        $this->assertEquals($expectedQuality, $gr->getItem(0)->quality);
+        $this->assertEquals($expectedQuality, $gildedRose->getItem(0)->quality);
 
-        $this->assertEquals($expectedSellIn, $gr->getItem(0)->sellIn);
+        $this->assertEquals($expectedSellIn, $gildedRose->getItem(0)->sellIn);
     }
 
     public function itemProvider(): array
@@ -37,22 +42,22 @@ class GuildedRoseTest extends TestCase
              * Normal items
              */
             'normal item before sell date' => [
-                'item' => new Item('normal', 10, 5),
+                'item' => new NormalItem(10, 5),
                 'expectedQuality' => 9,
                 'expectedSellIn' => 4,
             ],
             'normal item on sell date' => [
-                'item' => new Item('normal', 10, 0),
+                'item' => new NormalItem(10, 0),
                 'expectedQuality' => 8,
                 'expectedSellIn' => -1,
             ],
             'normal item after sell date' => [
-                'item' => new Item('normal', 10, -5),
+                'item' => new NormalItem(10, -5),
                 'expectedQuality' => 8,
                 'expectedSellIn' => -6,
             ],
             'normal item with quality of 0' => [
-                'item' => new Item('normal', 0, 5),
+                'item' => new NormalItem(0, 5),
                 'expectedQuality' => 0,
                 'expectedSellIn' => 4,
             ],
@@ -61,37 +66,37 @@ class GuildedRoseTest extends TestCase
              * Brie items
              */
             'brie item before sell date' => [
-                'item' => new Item('Aged Brie', 10, 5),
+                'item' => new AgedBrie(10, 5),
                 'expectedQuality' => 11,
                 'expectedSellIn' => 4,
             ],
             'brie item before sell date with maximum quality' => [
-                'item' => new Item('Aged Brie', 50, 5),
+                'item' => new AgedBrie(50, 5),
                 'expectedQuality' => 50,
                 'expectedSellIn' => 4,
             ],
             'brie item on sell date' => [
-                'item' => new Item('Aged Brie', 10, 0),
+                'item' => new AgedBrie(10, 0),
                 'expectedQuality' => 12,
                 'expectedSellIn' => -1,
             ],
             'brie item on sell date near maximum quality' => [
-                'item' => new Item('Aged Brie', 49, 0),
+                'item' => new AgedBrie(49, 0),
                 'expectedQuality' => 50,
                 'expectedSellIn' => -1,
             ],
             'brie item on sell date with maximum quality' => [
-                'item' => new Item('Aged Brie', 50, 0),
+                'item' => new AgedBrie(50, 0),
                 'expectedQuality' => 50,
                 'expectedSellIn' => -1,
             ],
             'brie item after sell date' => [
-                'item' => new Item('Aged Brie', 10, -10),
+                'item' => new AgedBrie(10, -10),
                 'expectedQuality' => 12,
                 'expectedSellIn' => -11,
             ],
             'brie item after sell date with maximum quality' => [
-                'item' => new Item('Aged Brie', 50, -10),
+                'item' => new AgedBrie(50, -10),
                 'expectedQuality' => 50,
                 'expectedSellIn' => -11,
             ],
@@ -100,18 +105,18 @@ class GuildedRoseTest extends TestCase
              * Sulfuras items
              */
             'sulfuras item before sell date' => [
-                'item' => new Item('Sulfuras, Hand of Ragnaros', 10, 5),
-                'expectedQuality' => 10,
+                'item' => new LegendaryItem(10, 5, 'Sulfuras, Hand of Ragnaros'),
+                'expectedQuality' => 80,
                 'expectedSellIn' => 5,
             ],
             'sulfuras item on sell date' => [
-                'item' => new Item('Sulfuras, Hand of Ragnaros', 10, 5),
-                'expectedQuality' => 10,
+                'item' => new LegendaryItem(10, 5, 'Sulfuras, Hand of Ragnaros'),
+                'expectedQuality' => 80,
                 'expectedSellIn' => 5,
             ],
             'sulfuras item after sell date' => [
-                'item' => new Item('Sulfuras, Hand of Ragnaros', 10, -1),
-                'expectedQuality' => 10,
+                'item' => new LegendaryItem(10, -1, 'Sulfuras, Hand of Ragnaros'),
+                'expectedQuality' => 80,
                 'expectedSellIn' => -1,
             ],
 
@@ -119,47 +124,50 @@ class GuildedRoseTest extends TestCase
              * Backstage passes
              */
             'backstage pass long before sell date' => [
-                'item' => new Item('Backstage passes to a TAFKAL80ETC concert', 10, 11),
+                'item' => new BackstagePass(10, 11, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 11,
                 'expectedSellIn' => 10,
             ],
             'backstage pass close to sell date' => [
-                'item' => new Item('Backstage passes to a TAFKAL80ETC concert', 10, 10),
+                'item' => new BackstagePass(10, 10, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 12,
                 'expectedSellIn' => 9,
             ],
             'backstage pass close to sell date at maximum quality' => [
-                'item' => new Item('Backstage passes to a TAFKAL80ETC concert', 50, 10),
+                'item' => new BackstagePass(50, 10, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 50,
                 'expectedSellIn' => 9,
             ],
             'backstage pass very close to sell date' => [
-                'item' => new Item('Backstage passes to a TAFKAL80ETC concert', 10, 5),
+                'item' => new BackstagePass(10, 5, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 13,
                 'expectedSellIn' => 4,
             ],
             'backstage pass very close to sell date at maximum quality' => [
-                'item' => new Item('Backstage passes to a TAFKAL80ETC concert', 50, 5),
+                'item' => new BackstagePass(50, 5, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 50,
                 'expectedSellIn' => 4,
             ],
             'backstage pass with one day left to sell' => [
-                'item' =>  new Item('Backstage passes to a TAFKAL80ETC concert', 10, 1),
+                'item' =>  new BackstagePass(10, 1, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 13,
                 'expectedSellIn' => 0,
             ],
             'backstage pass with one day left to sell at maximum quality' => [
-                'item' =>  new Item('Backstage passes to a TAFKAL80ETC concert', 50, 1),
+                'item' =>  new BackstagePass(50, 1, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 50,
                 'expectedSellIn' => 0,
             ],
+
+            // I would say this test is wrong and that expectedQuality should be 13 as I would interpret 0 as the day of
+            // the concert. I have left it in case this is not the case, however I would say this is wrong.
             'backstage pass on sell date' => [
-                'item' =>  new Item('Backstage passes to a TAFKAL80ETC concert', 10, 0),
+                'item' =>  new BackstagePass(10, 0, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 0,
                 'expectedSellIn' => -1,
             ],
             'backstage pass after sell date' => [
-                'item' =>  new Item('Backstage passes to a TAFKAL80ETC concert', 10, -1),
+                'item' =>  new BackstagePass(10, -1, 'Backstage passes to a TAFKAL80ETC concert'),
                 'expectedQuality' => 0,
                 'expectedSellIn' => -2,
             ],
@@ -167,36 +175,36 @@ class GuildedRoseTest extends TestCase
             /**
              * Conjured items
              */
-            // 'conjured item before sell date' => [
-            //     'item' => new Item('Conjured Mana Cake', 10, 10),
-            //     'expectedQuality' => 8,
-            //     'expectedSellIn' => 9,
-            // ],
-            // 'conjured item at zero quality' => [
-            //     'item' => new Item('Conjured Mana Cake', 0, 10),
-            //     'expectedQuality' => 0,
-            //     'expectedSellIn' => 9,
-            // ],
-            // 'conjured item on sell date' => [
-            //     'item' => new Item('Conjured Mana Cake', 10, 0),
-            //     'expectedQuality' => 6,
-            //     'expectedSellIn' => -1,
-            // ],
-            // 'conjured item on sell date at zero quality' => [
-            //     'item' => new Item('Conjured Mana Cake', 0, 0),
-            //     'expectedQuality' => 0,
-            //     'expectedSellIn' => -1,
-            // ],
-            // 'conjured item after sell date' => [
-            //     'item' => new Item('Conjured Mana Cake', 10, -10),
-            //     'expectedQuality' => 6,
-            //     'expectedSellIn' => -11,
-            // ],
-            // 'conjured item after sell date at zero quality' => [
-            //     'item' => new Item('Conjured Mana Cake', 0, -10),
-            //     'expectedQuality' => 0,
-            //     'expectedSellIn' => -11,
-            // ],
+             'conjured item before sell date' => [
+                 'item' => new ConjuredItem(10, 10, 'Conjured Mana Cake'),
+                 'expectedQuality' => 8,
+                 'expectedSellIn' => 9,
+             ],
+             'conjured item at zero quality' => [
+                 'item' => new ConjuredItem(0, 10, 'Conjured Mana Cake'),
+                 'expectedQuality' => 0,
+                 'expectedSellIn' => 9,
+             ],
+             'conjured item on sell date' => [
+                 'item' => new ConjuredItem(10, 0, 'Conjured Mana Cake'),
+                 'expectedQuality' => 6,
+                 'expectedSellIn' => -1,
+             ],
+             'conjured item on sell date at zero quality' => [
+                 'item' => new ConjuredItem(0, 0, 'Conjured Mana Cake'),
+                 'expectedQuality' => 0,
+                 'expectedSellIn' => -1,
+             ],
+             'conjured item after sell date' => [
+                 'item' => new ConjuredItem(10, -10, 'Conjured Mana Cake'),
+                 'expectedQuality' => 6,
+                 'expectedSellIn' => -11,
+             ],
+             'conjured item after sell date at zero quality' => [
+                 'item' => new ConjuredItem(0, -10, 'Conjured Mana Cake'),
+                 'expectedQuality' => 0,
+                 'expectedSellIn' => -11,
+             ],
         ];
     }
 }


### PR DESCRIPTION
Time: 1:46:41

- Altered GildedRose.php to call the nextDay method of every item in the array of items
- Added NormalItem.php which contains base logic of every item which can be overridden (this would be in Item.php if it wasn't for that pesky goblin in the corner, I don't like it when they insta-rage)
- Added AgedBrie.php, it's quality increases overtime
- Added LegendaryItem.php, it's quality and sellIn never changes, it's quality is always 80 and can never be altered
- Added BackstagePass.php, it's quality increases overtime, as the concert nears its quality improves more until its worthless
- Added the new item of ConjuredItem.php, it's quality degrades twice as fast as NormalItem.php
- Updated GuildedRoseTest.php to use new classes for item types

![Screenshot 2022-08-14 at 18 46 55](https://user-images.githubusercontent.com/50720501/184548721-83c10bbe-6e2b-4908-b931-1219586db4a5.png)
